### PR TITLE
Use format of 'finder' for analytics

### DIFF
--- a/app/controllers/business_support_controller.rb
+++ b/app/controllers/business_support_controller.rb
@@ -129,7 +129,7 @@ class BusinessSupportController < ApplicationController
 
   def send_slimmer_headers
     set_slimmer_headers(
-      :format => 'business-support-finder'
+      :format => 'finder'
     )
     set_slimmer_artefact(@artefact)
   end

--- a/spec/controllers/business_support_controller_spec.rb
+++ b/spec/controllers/business_support_controller_spec.rb
@@ -506,7 +506,7 @@ describe BusinessSupportController do
     it "should set the slimmer format header" do
       get :index
 
-      response.headers["#{Slimmer::Headers::HEADER_PREFIX}-Format"].should == "business-support-finder"
+      response.headers["#{Slimmer::Headers::HEADER_PREFIX}-Format"].should == "finder"
     end
   end
 end


### PR DESCRIPTION
Use the format of 'finder' instead of 'business-support-finder' in analytics
