### PR TITLE
Add question for business support type

### DIFF
--- a/app/controllers/business_support_controller.rb
+++ b/app/controllers/business_support_controller.rb
@@ -144,13 +144,6 @@ class BusinessSupportController < ApplicationController
     end
   end
 
-  def load_and_validate_types
-    @types = Types.find_by_slug(params[:types])
-    unless @types
-      render :status => :not_found, :text => ""
-    end
-  end
-
   def load_and_validate_location
     @location = Location.find_by_slug(params[:location])
     unless @location

--- a/app/controllers/business_support_controller.rb
+++ b/app/controllers/business_support_controller.rb
@@ -9,14 +9,16 @@ class BusinessSupportController < ApplicationController
     "What is your activity or business?",
     "What stage is your business at?",
     "How is your business structured?",
+    "What type of support are you interested in?",
     "Where is your business located?",
   ]
-  ACTIONS = %w(sectors stage structure location)
+  ACTIONS = %w(sectors stage structure types location)
 
   before_filter :load_artefact
-  before_filter :load_and_validate_sectors, :only => [:stage, :stage_submit, :structure, :structure_submit, :location, :location_submit, :support_options]
-  before_filter :load_and_validate_stage, :only => [:structure, :structure_submit, :location, :location_submit, :support_options]
-  before_filter :load_and_validate_structure, :only => [:location, :location_submit, :support_options]
+  before_filter :load_and_validate_sectors, :only => [:stage, :stage_submit, :structure, :structure_submit, :types, :types_submit, :location, :location_submit, :support_options]
+  before_filter :load_and_validate_stage, :only => [:structure, :structure_submit, :types, :types_submit, :location, :location_submit, :support_options]
+  before_filter :load_and_validate_structure, :only => [:types, :types_submit, :location, :location_submit, :support_options]
+  before_filter :load_and_validate_types, :only => [:location, :location_submit, :support_options]
   before_filter :load_and_validate_location, :only => [:support_options]
   after_filter :send_slimmer_headers
 
@@ -49,15 +51,28 @@ class BusinessSupportController < ApplicationController
 
   def structure_submit
     if Structure.find_by_slug(params[:structure])
-      redirect_to next_params.merge(:action => 'location', :structure => params[:structure])
+      redirect_to next_params.merge(:action => 'types', :structure => params[:structure])
     else
       redirect_to next_params.merge(:action => 'structure')
     end
   end
 
+  def types
+    @types = Types.all
+    setup_questions [@sectors, [@stage], [@structure]]
+  end
+
+  def types_submit
+    if Types.find_by_slug(params[:types])
+      redirect_to next_params.merge(:action => 'location', :types => params[:types])
+    else
+      redirect_to next_params.merge(:action => 'types')
+    end
+  end
+
   def location
     @locations = Location.all
-    setup_questions [@sectors, [@stage], [@structure]]
+    setup_questions [@sectors, [@stage], [@structure], [@types]]
   end
 
   def location_submit
@@ -75,7 +90,7 @@ class BusinessSupportController < ApplicationController
       :structure => @structure,
       :location => @location
     )
-    setup_questions [@sectors, [@stage], [@structure], [@location]]
+    setup_questions [@sectors, [@stage], [@structure], [@types], [@location]]
   end
 
   private
@@ -92,6 +107,7 @@ class BusinessSupportController < ApplicationController
     p[:sectors] = @sectors.map(&:slug).join('_') if @sectors
     p[:stage] = @stage.slug if @stage
     p[:structure] = @structure.slug if @structure
+    p[:types] = @types.slug if @types
     p
   end
 
@@ -116,6 +132,20 @@ class BusinessSupportController < ApplicationController
   def load_and_validate_structure
     @structure = Structure.find_by_slug(params[:structure])
     unless @structure
+      render :status => :not_found, :text => ""
+    end
+  end
+
+  def load_and_validate_types
+    @types = Types.find_by_slug(params[:types])
+    unless @types
+      render :status => :not_found, :text => ""
+    end
+  end
+
+  def load_and_validate_types
+    @types = Types.find_by_slug(params[:types])
+    unless @types
       render :status => :not_found, :text => ""
     end
   end

--- a/app/controllers/business_support_controller.rb
+++ b/app/controllers/business_support_controller.rb
@@ -88,6 +88,7 @@ class BusinessSupportController < ApplicationController
       :sectors => @sectors,
       :stage => @stage,
       :structure => @structure,
+      :types => @types,
       :location => @location
     )
     setup_questions [@sectors, [@stage], [@structure], [@types], [@location]]

--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -10,7 +10,7 @@ class Scheme < OpenStruct
       :stages => facets[:stage].slug,
       :business_types => facets[:structure].slug,
       :locations => facets[:location].slug,
-      :types => Types.convert_to_types(facets[:types].slug)
+      :types => facets[:types].imminence_slug
     )
     return [] if possible_schemes["results"].empty?
     schemes = content_api.business_support_schemes(possible_schemes["results"].map {|s| s["business_support_identifier"] } )

--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -9,7 +9,8 @@ class Scheme < OpenStruct
       :sectors => facets[:sectors].map(&:slug).join(','),
       :stages => facets[:stage].slug,
       :business_types => facets[:structure].slug,
-      :locations => facets[:location].slug
+      :locations => facets[:location].slug,
+      :types => Types.convert_to_types(facets[:types].slug)
     )
     return [] if possible_schemes["results"].empty?
     schemes = content_api.business_support_schemes(possible_schemes["results"].map {|s| s["business_support_identifier"] } )

--- a/app/models/types.rb
+++ b/app/models/types.rb
@@ -18,7 +18,7 @@ class Types < OpenStruct
     end
   end
   
-  def self.convert_to_types(slug)
+  def imminence_slug
     
     if slug == 'finance'
       business_support_types = 'finance,grant,loan,equity'

--- a/app/models/types.rb
+++ b/app/models/types.rb
@@ -1,0 +1,36 @@
+require 'ostruct'
+
+class Types < OpenStruct
+  HARDCODED_STAGES = {
+    "finance" => "Finance, grants and loans",
+    "all" => "Expertise, advice and finance"
+  }.map do |slug, name|
+    new(:slug => slug, :name => name)
+  end
+
+  def self.all
+    HARDCODED_STAGES
+  end
+
+  def self.find_by_slug(slug)
+    HARDCODED_STAGES.find do |stage|
+      stage.slug == slug
+    end
+  end
+  
+  def self.convert_to_types(slug)
+    
+    if slug == 'finance'
+      business_support_types = 'finance,grant,loan,equity'
+    elsif slug == 'all'
+      business_support_types = 'expertise-and-advice,recognition-award,equity,loan,finance,grant'
+    else
+      business_support_types = ''
+    end
+    business_support_types
+  end
+
+  def to_s
+    name
+  end
+end

--- a/app/views/business_support/location.html.erb
+++ b/app/views/business_support/location.html.erb
@@ -5,6 +5,7 @@
     <%= hidden_field_tag :sectors, params[:sectors] %>
     <%= hidden_field_tag :stage, params[:stage] %>
     <%= hidden_field_tag :structure, params[:structure] %>
+    <%= hidden_field_tag :types, params[:types] %>
     <div class="select-container find-location-for-service">
       <label for="select-location">Select a location
         <%= select_tag :location, options_from_collection_for_select(@locations, :slug, :name, params[:location]), :prompt => 'Select one...', :id => "select-location" %>

--- a/app/views/business_support/support_options.html.erb
+++ b/app/views/business_support/support_options.html.erb
@@ -3,15 +3,26 @@
 <div class="business-support-container group">
   <div class="results">
     <div class="results-wrapper">
-      <h2>Available support</h2>
-      <ul class="results-list">
-        <% @support_options.each do |support_option| %>
-          <li>
-            <%= link_to support_option.title, support_option.web_url %>
-            <p><%= support_option.short_description %></p>
-          </li>
-        <% end %>
-      </ul>
+      <% if @support_options.empty? %>
+        <p>
+          No business support schemes were found that match your search.
+        </p>
+        <p class="get-started">
+          <%= link_to sectors_path, :class => "big button" do %>
+            Start again <span class="indicator"></span>
+          <% end %>
+        </p>
+      <% else %>
+        <h2>Available support</h2>
+        <ul class="results-list">
+          <% @support_options.each do |support_option| %>
+            <li>
+              <%= link_to support_option.title, support_option.web_url %>
+              <p><%= support_option.short_description %></p>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/business_support/types.html.erb
+++ b/app/views/business_support/types.html.erb
@@ -1,0 +1,17 @@
+<%= render :partial => 'completed_questions' %>
+
+<%= current_question do %>
+  <%= form_tag types_path do %>
+    <%= hidden_field_tag :sectors, params[:sectors] %>
+    <%= hidden_field_tag :stage, params[:stage] %>
+    <%= hidden_field_tag :structure, params[:structure] %>
+    <div class="select-container">
+      <label for="select-types">Select a type of business support
+        <%= select_tag :types, options_from_collection_for_select(@types, :slug, :name, params[:types]), :prompt => 'Select one...', :id => "select-types" %>
+      </label>
+    </div>
+    <%= submit_tag "Next step", :class => "button medium" %>
+  <% end %>
+<% end %>
+
+<%= render :partial => 'upcoming_questions' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ BusinessSupportFinder::Application.routes.draw do
   post "/#{APP_SLUG}/stage" => "business_support#stage_submit"
   get "/#{APP_SLUG}/structure" => "business_support#structure", :as => :structure
   post "/#{APP_SLUG}/structure" => "business_support#structure_submit"
+  get "/#{APP_SLUG}/types" => "business_support#types", :as => :types
+  post "/#{APP_SLUG}/types" => "business_support#types_submit"
   get "/#{APP_SLUG}/location" => "business_support#location", :as => :location
   post "/#{APP_SLUG}/location" => "business_support#location_submit"
   get "/#{APP_SLUG}/support-options" => "business_support#support_options", :as => :support_options

--- a/spec/integration/business_location_page_spec.rb
+++ b/spec/integration/business_location_page_spec.rb
@@ -3,15 +3,16 @@ require 'spec_helper'
 describe "Business location page" do
 
   specify "inspecting the page" do
-    visit "/#{APP_SLUG}/location?sectors=health_manufacturing&stage=start-up&structure=partnership"
+    visit "/#{APP_SLUG}/location?sectors=health_manufacturing&stage=start-up&structure=partnership&types=finance"
 
     assert_completed_questions(
       1 => ["What is your activity or business?", ["Health", "Manufacturing"]],
       2 => ["What stage is your business at?", ["Start-up"]],
-      3 => ["How is your business structured?", ["Partnership"]]
+      3 => ["How is your business structured?", ["Partnership"]],
+      4 => ["What type of support are you interested in?", ["Finance, grants and loans"]]
     )
 
-    assert_current_question(4, "Where is your business located?")
+    assert_current_question(5, "Where is your business located?")
 
     within '.current-question' do
       page.should have_select("Select a location", :options => [
@@ -35,7 +36,7 @@ describe "Business location page" do
   end
 
   specify "with a location already selected" do
-    visit "/#{APP_SLUG}/location?sectors=health_manufacturing&stage=start-up&structure=partnership&location=wales"
+    visit "/#{APP_SLUG}/location?sectors=health_manufacturing&stage=start-up&structure=partnership&types=finance&location=wales"
 
     within '.current-question' do
       page.should have_select("Select a location", :options => [

--- a/spec/integration/business_stage_page_spec.rb
+++ b/spec/integration/business_stage_page_spec.rb
@@ -25,7 +25,8 @@ describe "Business stage page" do
 
     assert_upcoming_questions(
       3 => "How is your business structured?",
-      4 => "Where is your business located?"
+      4 => "What type of support are you interested in?",
+      5 => "Where is your business located?"
     )
 
     select "Grow and sustain", :from => "Select a stage"

--- a/spec/integration/business_structure_page_spec.rb
+++ b/spec/integration/business_structure_page_spec.rb
@@ -27,14 +27,15 @@ describe "Business structure page" do
     end
 
     assert_upcoming_questions(
-      4 => "Where is your business located?"
+      4 => "What type of support are you interested in?",
+      5 => "Where is your business located?"
     )
 
     select "Sole trader", :from => "Select a structure"
 
     click_on "Next step"
 
-    i_should_be_on "/#{APP_SLUG}/location", :ignore_query => true
+    i_should_be_on "/#{APP_SLUG}/types", :ignore_query => true
   end
 
   specify "with a structure already selected" do

--- a/spec/integration/finding_support_options_spec.rb
+++ b/spec/integration/finding_support_options_spec.rb
@@ -4,7 +4,13 @@ describe "Finding support options" do
 
   specify "Happy path through the app" do
     imminence_has_business_support_schemes(
-      {"sectors" => "education,hospitality-and-catering", "stages" => "start-up", "business_types" => "public-limited-company", "locations" => "wales"},
+      {
+        "sectors" => "education,hospitality-and-catering",
+        "stages" => "start-up",
+        "business_types" => "public-limited-company",
+        "locations" => "wales",
+        "types" => "finance,grant,loan,equity"
+      },
       [
         {"title" => "Graduate start-up", "business_support_identifier" => "graduate-start-up"},
         {"title" => "Manufacturing Services - Wales", "business_support_identifier" => "manufacturing-services-wales"},
@@ -76,6 +82,26 @@ describe "Finding support options" do
       click_on 'Next step'
     end
 
+    i_should_be_on "/#{APP_SLUG}/types", :ignore_query => true
+
+    within_section 'completed question 1' do
+      page.should have_content("Education")
+      page.should have_content("Hospitality and Catering")
+    end
+    within_section 'completed question 2' do
+      page.should have_content("Start-up")
+    end
+    within_section 'completed question 3' do
+      page.should have_content("Public limited company")
+    end
+
+    within '.current-question' do
+      page.should have_content("What type of support are you interested in?")
+
+      select 'Finance, grants and loans', :from => "Select a type of business support"
+      click_on 'Next step'
+    end
+
     i_should_be_on "/#{APP_SLUG}/location", :ignore_query => true
 
     within_section 'completed question 1' do
@@ -87,6 +113,9 @@ describe "Finding support options" do
     end
     within_section 'completed question 3' do
       page.should have_content("Public limited company")
+    end
+    within_section 'completed question 4' do
+      page.should have_content("Finance, grants and loans")
     end
 
     within '.current-question' do

--- a/spec/integration/sectors_page_spec.rb
+++ b/spec/integration/sectors_page_spec.rb
@@ -42,7 +42,8 @@ describe "selecting business sectors" do
     assert_upcoming_questions(
       2 => "What stage is your business at?",
       3 => "How is your business structured?",
-      4 => "Where is your business located?"
+      4 => "What type of support are you interested in?",
+      5 => "Where is your business located?"
     )
 
     click_add_link "Education"

--- a/spec/integration/support_options_page_spec.rb
+++ b/spec/integration/support_options_page_spec.rb
@@ -4,7 +4,13 @@ describe "Support options page" do
 
   specify "inspecting the support options page" do
     imminence_has_business_support_schemes(
-      {"sectors" => "health,manufacturing", "stages" => "start-up", "business_types" => "partnership", "locations" => "england"},
+      {
+        "sectors" => "health,manufacturing",
+        "stages" => "start-up",
+        "business_types" => "partnership",
+        "locations" => "england",
+        "types" => "finance,grant,loan,equity"
+      },
       [
         {"title" => "Graduate start-up", "business_support_identifier" => "graduate-start-up"},
         {"title" => "High Potential Starts", "business_support_identifier" => "high-potential-starts"},
@@ -28,13 +34,14 @@ describe "Support options page" do
       }
     )
 
-    visit "/#{APP_SLUG}/support-options?sectors=health_manufacturing&stage=start-up&structure=partnership&location=england"
+    visit "/#{APP_SLUG}/support-options?sectors=health_manufacturing&stage=start-up&structure=partnership&location=england&types=finance"
 
     assert_completed_questions(
       1 => ["What is your activity or business?", ["Health", "Manufacturing"]],
       2 => ["What stage is your business at?", ["Start-up"]],
       3 => ["How is your business structured?", ["Partnership"]],
-      4 => ["Where is your business located?", ["England"]]
+      4 => ["What type of support are you interested in?", ["Finance, grants and loans"]],
+      5 => ["Where is your business located?", ["England"]]
     )
 
     page.should_not have_selector('.completed-questions')
@@ -56,19 +63,22 @@ describe "Support options page" do
   end
 
   specify "inspecting the 'change this answer' links" do
-    visit "/#{APP_SLUG}/support-options?sectors=health_manufacturing&stage=start-up&structure=partnership&location=england"
+    visit "/#{APP_SLUG}/support-options?sectors=health_manufacturing&stage=start-up&structure=partnership&location=england&types=finance"
 
     within_section "completed question 1" do
-      page.should have_link("Change this answer", :href => "/#{APP_SLUG}/sectors?location=england&sectors=health_manufacturing&stage=start-up&structure=partnership")
+      page.should have_link("Change this answer", :href => "/#{APP_SLUG}/sectors?location=england&sectors=health_manufacturing&stage=start-up&structure=partnership&types=finance")
     end
     within_section "completed question 2" do
-      page.should have_link("Change this answer", :href => "/#{APP_SLUG}/stage?location=england&sectors=health_manufacturing&stage=start-up&structure=partnership")
+      page.should have_link("Change this answer", :href => "/#{APP_SLUG}/stage?location=england&sectors=health_manufacturing&stage=start-up&structure=partnership&types=finance")
     end
     within_section "completed question 3" do
-      page.should have_link("Change this answer", :href => "/#{APP_SLUG}/structure?location=england&sectors=health_manufacturing&stage=start-up&structure=partnership")
+      page.should have_link("Change this answer", :href => "/#{APP_SLUG}/structure?location=england&sectors=health_manufacturing&stage=start-up&structure=partnership&types=finance")
     end
     within_section "completed question 4" do
-      page.should have_link("Change this answer", :href => "/#{APP_SLUG}/location?location=england&sectors=health_manufacturing&stage=start-up&structure=partnership")
+      page.should have_link("Change this answer", :href => "/#{APP_SLUG}/types?location=england&sectors=health_manufacturing&stage=start-up&structure=partnership&types=finance")
+    end
+    within_section "completed question 5" do
+      page.should have_link("Change this answer", :href => "/#{APP_SLUG}/location?location=england&sectors=health_manufacturing&stage=start-up&structure=partnership&types=finance")
     end
   end
 end

--- a/spec/integration/support_options_page_spec.rb
+++ b/spec/integration/support_options_page_spec.rb
@@ -62,6 +62,31 @@ describe "Support options page" do
     end
   end
 
+  specify "inspecting the support options page with no results" do
+    imminence_has_business_support_schemes(
+      {
+        "sectors" => "health,manufacturing",
+        "stages" => "start-up",
+        "business_types" => "partnership",
+        "locations" => "england",
+        "types" => "award-scheme"
+      },
+      [
+        {"title" => "Graduate start-up", "business_support_identifier" => "graduate-start-up"},
+      ]
+    )
+
+    visit "/#{APP_SLUG}/support-options?sectors=health_manufacturing&stage=start-up&structure=partnership&location=england&types=finance"
+
+    within '.results' do
+      page.should have_content("No business support schemes were found that match your search.")
+
+      page.should have_link("Start again", :href => "/#{APP_SLUG}/sectors")
+
+      page.should_not have_content("Available support")
+    end
+  end
+
   specify "inspecting the 'change this answer' links" do
     visit "/#{APP_SLUG}/support-options?sectors=health_manufacturing&stage=start-up&structure=partnership&location=england&types=finance"
 

--- a/spec/integration/types_page_spec.rb
+++ b/spec/integration/types_page_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe "Types page" do
+
+  specify "inspecting the page" do
+    visit "/#{APP_SLUG}/types?sectors=health_manufacturing&stage=start-up&structure=partnership"
+
+    assert_completed_questions(
+      1 => ["What is your activity or business?", ["Health", "Manufacturing"]],
+      2 => ["What stage is your business at?", ["Start-up"]],
+      3 => ["How is your business structured?", ["Partnership"]]
+    )
+
+    assert_current_question(4, "What type of support are you interested in?")
+
+    within '.current-question' do
+      page.should have_select("Select a type of business support", :options => [
+        'Select one...',
+        'Finance, grants and loans',
+        'Expertise, advice and finance'
+      ])
+
+      page.should have_button("Next step")
+    end
+
+    assert_upcoming_questions(
+      5 => "Where is your business located?"
+    )
+
+    select "Finance", :from => "Select a type of business support"
+
+    click_on "Next step"
+
+    i_should_be_on "/#{APP_SLUG}/location", :ignore_query => true
+  end
+
+  specify "with a type already selected" do
+    visit "/#{APP_SLUG}/types?sectors=health_manufacturing&stage=start-up&structure=sole-trader&types=finance"
+
+    within '.current-question' do
+      page.should have_select("Select a type of business support", :options => [
+        'Select one...',
+        'Finance, grants and loans',
+        'Expertise, advice and finance',
+      ], :selected => 'Finance, grants and loans')
+    end
+  end
+end

--- a/spec/models/scheme_spec.rb
+++ b/spec/models/scheme_spec.rb
@@ -7,6 +7,7 @@ describe Scheme do
       @sectors = Sector.find_by_slugs(%w(health manufacturing))
       @stage = Stage.find_by_slug('start-up')
       @structure = Structure.find_by_slug('partnership')
+      @types = Types.find_by_slug('finance')
       @location = Location.find_by_slug('wales')
       GdsApi::Imminence.any_instance.stub(:business_support_schemes).and_return("results" => [])
       GdsApi::ContentApi.any_instance.stub(:business_support_schemes).and_return("results" => [])
@@ -21,10 +22,15 @@ describe Scheme do
 
     it "should lookup available schemes in imminence" do
       GdsApi::Imminence.any_instance.should_receive(:business_support_schemes).
-        with(:sectors => "health,manufacturing", :stages => "start-up", :business_types => "partnership", :locations => "wales").
+        with(
+          :sectors => "health,manufacturing",
+          :stages => "start-up",
+          :business_types => "partnership",
+          :types => "finance,grant,loan,equity",
+          :locations => "wales").
         and_return("results" => [])
 
-      Scheme.lookup(:sectors => @sectors, :stage => @stage, :structure => @structure, :location => @location)
+      Scheme.lookup(:sectors => @sectors, :stage => @stage, :structure => @structure, :types => @types, :location => @location)
     end
 
     it "should fetch the imminence schemes from content_api" do
@@ -37,7 +43,7 @@ describe Scheme do
       GdsApi::ContentApi.any_instance.should_receive(:business_support_schemes).with(%w(scheme-1 scheme-3 scheme-2)).
         and_return("results" => [])
 
-      Scheme.lookup(:sectors => @sectors, :stage => @stage, :structure => @structure, :location => @location)
+      Scheme.lookup(:sectors => @sectors, :stage => @stage, :structure => @structure, :types => @types, :location => @location)
     end
 
     it "should construct instances of Scheme for each result and return them" do
@@ -48,7 +54,7 @@ describe Scheme do
       Scheme.should_receive(:new).with(:artefact1).and_return(:scheme1)
       Scheme.should_receive(:new).with(:artefact2).and_return(:scheme2)
 
-      schemes = Scheme.lookup(:sectors => @sectors, :stage => @stage, :structure => @structure, :location => @location)
+      schemes = Scheme.lookup(:sectors => @sectors, :stage => @stage, :structure => @structure, :types => @types, :location => @location)
       schemes.should == [:scheme1, :scheme2]
     end
 
@@ -56,7 +62,7 @@ describe Scheme do
       GdsApi::Imminence.any_instance.stub(:business_support_schemes).and_return("results" => [])
       GdsApi::ContentApi.any_instance.should_not_receive(:business_support_schemes)
 
-      schemes = Scheme.lookup(:sectors => @sectors, :stage => @stage, :structure => @structure, :location => @location)
+      schemes = Scheme.lookup(:sectors => @sectors, :stage => @stage, :structure => @structure, :types => @types, :location => @location)
       schemes.should == []
     end
   end


### PR DESCRIPTION
Adds a new question to the business support scheme flow.

Also adds a message to the results screen to deal with the case where there are no schemes available.
