### PR TITLE
Inputs submits to buttons

### DIFF
--- a/app/views/business_support/location.html.erb
+++ b/app/views/business_support/location.html.erb
@@ -11,6 +11,6 @@
         <%= select_tag :location, options_from_collection_for_select(@locations, :slug, :name, params[:location]), :prompt => 'Select one...', :id => "select-location" %>
       </label>
     </div>
-    <%= submit_tag "Find support", :class => "button medium" %>
+    <%= button_tag "Find support", :class => "button medium" %>
   <% end %>
 <% end %>

--- a/app/views/business_support/stage.html.erb
+++ b/app/views/business_support/stage.html.erb
@@ -8,7 +8,7 @@
         <%= select_tag :stage, options_from_collection_for_select(@stages, :slug, :name, params[:stage]), :prompt => 'Select one...', :id => "select-stage" %>
       </label>
     </div>
-    <%= submit_tag "Next step", :class => "button medium" %>
+    <%= button_tag "Next step", :class => "button medium" %>
   <% end %>
 <% end %>
 

--- a/app/views/business_support/structure.html.erb
+++ b/app/views/business_support/structure.html.erb
@@ -9,7 +9,7 @@
         <%= select_tag :structure, options_from_collection_for_select(@structures, :slug, :name, params[:structure]), :prompt => 'Select one...', :id => "select-structure" %>
       </label>
     </div>
-    <%= submit_tag "Next step", :class => "button medium" %>
+    <%= button_tag "Next step", :class => "button medium" %>
   <% end %>
 <% end %>
 

--- a/app/views/business_support/types.html.erb
+++ b/app/views/business_support/types.html.erb
@@ -15,7 +15,7 @@
         </li>
       <% end %>
     </ul>
-    <%= submit_tag "Next step", :class => "button medium" %>
+    <%= button_tag "Next step", :class => "button medium" %>
   <% end %>
 <% end %>
 


### PR DESCRIPTION
Changing `input[type=submit]` tags to `button[type=submit]` to allow the CSS fixes to work from this pull request:

alphagov/static#124

Associated with the following pull requests:

alphagov/static#127
alphagov/frontend#155
alphagov/feedback#19
alphagov/licence-finder#25
alphagov/smart-answers#106
