### PR TITLE
Remove the 'exiting a business' business stage

### DIFF
--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -5,7 +5,6 @@ class Stage < OpenStruct
     "pre-startup" => "Pre-startup",
     "start-up" => "Start-up",
     "grow-and-sustain" => "Grow and sustain",
-    "exiting-a-business" => "Exiting a business",
   }.map do |slug, name|
     new(:slug => slug, :name => name)
   end

--- a/spec/integration/business_stage_page_spec.rb
+++ b/spec/integration/business_stage_page_spec.rb
@@ -17,7 +17,6 @@ describe "Business stage page" do
         'Pre-startup',
         'Start-up',
         'Grow and sustain',
-        'Exiting a business',
       ])
 
       page.should have_button("Next step")
@@ -45,7 +44,6 @@ describe "Business stage page" do
         'Pre-startup',
         'Start-up',
         'Grow and sustain',
-        'Exiting a business',
       ], :selected => 'Grow and sustain')
     end
   end

--- a/spec/models/stage_spec.rb
+++ b/spec/models/stage_spec.rb
@@ -6,10 +6,10 @@ describe Stage do
     it "should return all the hardcoded stages with slugs" do
       stages = Stage.all
 
-      stages.size.should == 4
+      stages.size.should == 3
 
-      stages.map(&:name).should == ["Pre-startup", "Start-up", "Grow and sustain", "Exiting a business"]
-      stages.map(&:slug).should == ["pre-startup", "start-up", "grow-and-sustain", "exiting-a-business"]
+      stages.map(&:name).should == ["Pre-startup", "Start-up", "Grow and sustain"]
+      stages.map(&:slug).should == ["pre-startup", "start-up", "grow-and-sustain"]
     end
   end
 


### PR DESCRIPTION
This shouldn't have been there.  It came across with the data from the BusinessLink tool.
