### PR TITLE
bump plek to 1.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://gems.gemfury.com/vo6ZrmjBQu5szyywDszE/'
 gem 'rails', '3.2.8'
 
 gem 'slimmer', '3.9.4'
-gem 'plek', '0.4.0'
+gem 'plek', '1.0.0'
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://gems.gemfury.com/vo6ZrmjBQu5szyywDszE/'
 
 gem 'rails', '3.2.8'
 
-gem 'slimmer', '3.9.4'
+gem 'slimmer', '3.9.5'
 gem 'plek', '1.0.0'
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://gems.gemfury.com/vo6ZrmjBQu5szyywDszE/'
 gem 'rails', '3.2.8'
 
 gem 'slimmer', '3.9.5'
-gem 'plek', '1.0.0'
+gem 'plek', '1.1.0'
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,7 @@ GEM
     simplecov-html (0.5.3)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (3.9.4)
+    slimmer (3.9.5)
       json
       lrucache (~> 0.1.3)
       nokogiri (~> 1.5.0)
@@ -200,7 +200,7 @@ DEPENDENCIES
   sass-rails (~> 3.2.3)
   simplecov
   simplecov-rcov
-  slimmer (= 3.9.4)
+  slimmer (= 3.9.5)
   uglifier (>= 1.0.3)
   unicorn
   webmock

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,7 @@ GEM
     multi_json (1.3.6)
     nokogiri (1.5.5)
     null_logger (0.0.1)
-    plek (1.0.0)
+    plek (1.1.0)
       builder
     poltergeist (0.7.0)
       capybara (~> 1.1)
@@ -192,7 +192,7 @@ DEPENDENCIES
   govuk_frontend_toolkit (= 0.2.1)
   lograge
   nokogiri
-  plek (= 1.0.0)
+  plek (= 1.1.0)
   poltergeist (= 0.7.0)
   rails (= 3.2.8)
   rspec-rails (= 2.11.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,7 @@ GEM
       mail (> 2.2.5)
       mime-types
       xml-simple
-    builder (3.0.3)
+    builder (3.0.4)
     capybara (1.1.2)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -85,7 +85,7 @@ GEM
     multi_json (1.3.6)
     nokogiri (1.5.5)
     null_logger (0.0.1)
-    plek (0.4.0)
+    plek (1.0.0)
       builder
     poltergeist (0.7.0)
       capybara (~> 1.1)
@@ -192,7 +192,7 @@ DEPENDENCIES
   govuk_frontend_toolkit (= 0.2.1)
   lograge
   nokogiri
-  plek (= 0.4.0)
+  plek (= 1.0.0)
   poltergeist (= 0.7.0)
   rails (= 3.2.8)
   rspec-rails (= 2.11.0)


### PR DESCRIPTION
Please read the Plek v1.0.0 [CHANGELOG](https://github.com/alphagov/plek/blob/master/CHANGELOG.md) to understand the implications.
