### PR TITLE
Bump eventmachine

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,7 @@ GEM
     crack (0.3.1)
     diff-lcs (1.1.3)
     erubis (2.7.0)
-    eventmachine (0.12.10)
+    eventmachine (1.0.3)
     exception_notification (2.6.1)
       actionmailer (>= 3.0.4)
     execjs (1.4.0)


### PR DESCRIPTION
To fix compilation issues on newer systems (Ubuntu 12.04)
