### PR TITLE
Align headings with new static style

### DIFF
--- a/app/assets/stylesheets/licence-finder.scss
+++ b/app/assets/stylesheets/licence-finder.scss
@@ -35,10 +35,12 @@ header.page-header hgroup {
 
 /* reset margin on start */
 .start-page header.page-header hgroup {
-  margin-right: 15em;
+  margin: 0 24em 0 0;
+  padding: 1em 2em 2em 2em;
 
   @include media(mobile) {
     margin-right: 0;
+    padding-bottom: 0;
   }
 }
 


### PR DESCRIPTION
Make the page headings look like they do in the new styles from:

https://github.com/alphagov/static/pull/253
