### PR TITLE
Bump toolkit to 0.32.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,4 +39,4 @@ group :development, :test do
   gem 'poltergeist', '0.7.0'
 end
 
-gem 'govuk_frontend_toolkit', '0.2.1'
+gem 'govuk_frontend_toolkit', '0.32.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,8 +62,9 @@ GEM
       lrucache (~> 0.1.1)
       null_logger
       plek
-    govuk_frontend_toolkit (0.2.1)
+    govuk_frontend_toolkit (0.32.2)
       rails (>= 3.1.0)
+      sass (>= 3.2.0)
     hike (1.2.1)
     http_parser.rb (0.5.3)
     i18n (0.6.1)
@@ -190,7 +191,7 @@ DEPENDENCIES
   capybara (= 1.1.2)
   exception_notification
   gds-api-adapters (= 4.1.3)
-  govuk_frontend_toolkit (= 0.2.1)
+  govuk_frontend_toolkit (= 0.32.2)
   lograge (= 0.2.0)
   nokogiri
   plek (= 1.1.0)


### PR DESCRIPTION
Continuation of this work: https://github.com/alphagov/static/pull/270

Associated with (though they don't need to be merged simultaneously):

https://github.com/alphagov/calendars/pull/37
https://github.com/alphagov/design-principles/pull/47
https://github.com/alphagov/feedback/pull/53
https://github.com/alphagov/licence-finder/pull/36
https://github.com/alphagov/smart-answers/pull/466
https://github.com/alphagov/trade-tariff-frontend/pull/80
https://github.com/alphagov/transaction-wrappers/pull/28
