### PR TITLE
Disable formatted routes.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,16 +1,18 @@
 BusinessSupportFinder::Application.routes.draw do
 
-  get "/#{APP_SLUG}" => "business_support#start", :as => :start
-  get "/#{APP_SLUG}/sectors" => "business_support#sectors", :as => :sectors
-  get "/#{APP_SLUG}/stage" => "business_support#stage", :as => :stage
-  post "/#{APP_SLUG}/stage" => "business_support#stage_submit"
-  get "/#{APP_SLUG}/structure" => "business_support#structure", :as => :structure
-  post "/#{APP_SLUG}/structure" => "business_support#structure_submit"
-  get "/#{APP_SLUG}/types" => "business_support#types", :as => :types
-  post "/#{APP_SLUG}/types" => "business_support#types_submit"
-  get "/#{APP_SLUG}/location" => "business_support#location", :as => :location
-  post "/#{APP_SLUG}/location" => "business_support#location_submit"
-  get "/#{APP_SLUG}/support-options" => "business_support#support_options", :as => :support_options
+  with_options :format => false do |routes|
+    routes.get "/#{APP_SLUG}" => "business_support#start", :as => :start
+    routes.get "/#{APP_SLUG}/sectors" => "business_support#sectors", :as => :sectors
+    routes.get "/#{APP_SLUG}/stage" => "business_support#stage", :as => :stage
+    routes.post "/#{APP_SLUG}/stage" => "business_support#stage_submit"
+    routes.get "/#{APP_SLUG}/structure" => "business_support#structure", :as => :structure
+    routes.post "/#{APP_SLUG}/structure" => "business_support#structure_submit"
+    routes.get "/#{APP_SLUG}/types" => "business_support#types", :as => :types
+    routes.post "/#{APP_SLUG}/types" => "business_support#types_submit"
+    routes.get "/#{APP_SLUG}/location" => "business_support#location", :as => :location
+    routes.post "/#{APP_SLUG}/location" => "business_support#location_submit"
+    routes.get "/#{APP_SLUG}/support-options" => "business_support#support_options", :as => :support_options
+  end
 
   root :to => redirect("/#{APP_SLUG}", :status => 302)
 end


### PR DESCRIPTION
Routes like /business-support-finder.json are currently blowing up because we don't have a json template.  This changes them to 404 instead.
