### PR TITLE
Remove business stage (Exiting a business)

### DIFF
--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -4,8 +4,7 @@ class Stage < OpenStruct
   HARDCODED_STAGES = {
     "pre-start" => "Pre-start",
     "start-up" => "Start-up",
-    "grow-and-sustain" => "Grow and sustain",
-    "exiting-a-business" => "Exiting a business"
+    "grow-and-sustain" => "Grow and sustain"
   }.map do |slug, name|
     new(:slug => slug, :name => name)
   end

--- a/spec/models/stage_spec.rb
+++ b/spec/models/stage_spec.rb
@@ -6,10 +6,10 @@ describe Stage do
     it "should return all the hardcoded stages with slugs" do
       stages = Stage.all
 
-      stages.size.should == 4
+      stages.size.should == 3
 
-      stages.map(&:name).should == ["Pre-start", "Start-up", "Grow and sustain", "Exiting a business"]
-      stages.map(&:slug).should == ["pre-start", "start-up", "grow-and-sustain", "exiting-a-business"]
+      stages.map(&:name).should == ["Pre-start", "Start-up", "Grow and sustain"]
+      stages.map(&:slug).should == ["pre-start", "start-up", "grow-and-sustain"]
     end
   end
 


### PR DESCRIPTION
See story https://www.pivotaltracker.com/s/projects/537731/stories/59567786

This commit removes the Exiting a business option from the Business stage drop-down on the new Finance and support for your business tool. There is another commit on the imminence branch of the same name that removes the data from Imminence.
