### PR TITLE
Remove format names

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,7 @@
       <main id="content" role="main">
         <header class="page-header group">
           <div>
-            <h1><span>Quick answer</span>Finance and support for your business</h1>
+            <h1>Finance and support for your business</h1>
           </div>
         </header>
         <%= yield %>

--- a/spec/features/start_page_spec.rb
+++ b/spec/features/start_page_spec.rb
@@ -9,7 +9,6 @@ describe "Start page" do
     within '#content' do
       within 'header' do
         page.should have_content("Finance and support for your business")
-        page.should have_content("Quick answer")
       end
 
       within 'article[role=article]' do


### PR DESCRIPTION
This update removes the format name from content pages (eg Guide, Quick Answers, Service, etc) because they are not useful to users and are a waste of screen space, particularly on small viewports where space is tight and it's more important to get actual content into view.

Pull requests are also in for other apps that need updating to implement this GOV.UK wide, including [frontend](https://github.com/alphagov/frontend/pull/482), [static](https://github.com/alphagov/static/pull/346), [calendars](https://github.com/alphagov/calendars/pull/48), [business-support-finder](https://github.com/alphagov/business-support-finder/pull/49), [smart-answers](https://github.com/alphagov/smart-answers/pull/646) and [licence-finder](https://github.com/alphagov/licence-finder/pull/45).
