### PR TITLE
Fix broken PhantomJS tests, due to SSL

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,4 +1,8 @@
 require 'capybara/rspec'
 require 'capybara/poltergeist'
 
+Capybara.register_driver :poltergeist do |app|
+  Capybara::Poltergeist::Driver.new(app, { phantomjs_options: ['--ssl-protocol=TLSv1'] })
+end
+
 Capybara.javascript_driver = :poltergeist


### PR DESCRIPTION
phantomjs defaults to using SSLv3, which has now been disabled
everywhere.  The protocol used can be changed with an option:

 --ssl-protocol=<val>                 Sets the SSL protocol
   (supported protocols: 'SSLv3' (default), 'SSLv2', 'TLSv1', 'any')

This PR makes poltergeist and the  task set this option when invoking phantomjs.

See: https://github.com/alphagov/frontend/commit/e648bfc2a0c9e95b854429638149443dce3a573b#diff-7a6aaeae51145fd37e71db58212fd18bR104
