### PR TITLE
Update to work with new slimmer provided layout

### DIFF
--- a/app/assets/stylesheets/views/search.css.scss
+++ b/app/assets/stylesheets/views/search.css.scss
@@ -83,7 +83,7 @@ $right-to-left: false !default;
   label {
     @include ig-core-14;
 
-    &.title {  
+    &.title {
       @include copy-19;
       font-weight: bold;
       display:block;
@@ -313,7 +313,7 @@ ul.results-list {
       }
 
       a:hover {
-        text-decoration:underline; 
+        text-decoration:underline;
       }
     }
 
@@ -509,22 +509,24 @@ ul.results-list {
 
 // CUSTOM STYLES AND OVERRIDES
 // WRITTEN FOR THIS PROTOTYPE
-.search-page main {
-  header.page-header {
-    div {
-      margin:0;
-      margin-left:-4px;
-    }
+.search-page main header.page-header div {
+  margin-bottom: $gutter-half;
+  @include media(tablet){
+    margin-bottom: $gutter*2;
   }
 }
 
 .search-page .article-container {
-  margin-right:0; 
+  margin-right:0;
   max-width:none;
 }
 
 .business-support-index {
+  margin: 0 -$gutter-half;
+
   @include media(tablet) {
+    margin: 0 -$gutter;
+
     .block-2 {
       float: left;
       width: 33.333%;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,7 @@
   </head>
   <body class="mainstream">
     <div id="wrapper" class="answer business-support-finder <%= yield :page_class %>">
+      <% if content_for?(:after_content) %><div class="grid-row"><% end %>
       <main id="content" role="main">
         <header class="page-header group">
           <div>
@@ -20,6 +21,7 @@
         <%= yield %>
       </main>
       <%= yield :after_content %>
+      <% if content_for?(:after_content) %></div><% end %>
     </div>
     <%= javascript_include_tag "application" %>
   </body>


### PR DESCRIPTION
By default the related links now float. This wraps the main and the
related in a grid row so that the elements float nicely together.
Otherwise the related links will float into the page footer.

This is the change needed to go with alphagov/static#530
