### PR TITLE
Revert "No gems in this project use Gemfury anymore, so remove its sourc...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+source 'https://BnrJb6FZyzspBboNJzYZ@gem.fury.io/govuk/'
 
 gem 'rails', '3.2.17'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,6 @@
 GEM
   remote: https://rubygems.org/
+  remote: https://BnrJb6FZyzspBboNJzYZ@gem.fury.io/govuk/
   specs:
     PriorityQueue (0.1.2)
     actionmailer (3.2.17)


### PR DESCRIPTION
Reverts alphagov/business-support-finder#73

Following a conversation on Slack in #developers:
[16:27] Alex Tomlins: Note: you can only drop the gemfury line if it's using a semi=recent version of govuk_frontend_toolkit.
[16:27] Alex Tomlins: where semi-recent means >= 0.41.1
[16:27] Alex Tomlins: Versions older than that are only on gemfury for $reasons.

Sorry, @benilovj. Didn't realise this!
