### PR TITLE
Upgrade the `govuk_frontend_toolkit` gem so we can remove Gemfury

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source 'https://rubygems.org'
-source 'https://BnrJb6FZyzspBboNJzYZ@gem.fury.io/govuk/'
 
 gem 'rails', '3.2.17'
 
@@ -37,4 +36,4 @@ group :development, :test do
   gem 'poltergeist', '1.4.1'
 end
 
-gem 'govuk_frontend_toolkit', '0.32.2'
+gem 'govuk_frontend_toolkit', '1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,5 @@
 GEM
   remote: https://rubygems.org/
-  remote: https://BnrJb6FZyzspBboNJzYZ@gem.fury.io/govuk/
   specs:
     PriorityQueue (0.1.2)
     actionmailer (3.2.17)
@@ -55,7 +54,7 @@ GEM
       null_logger
       plek
       rest-client (~> 1.6.3)
-    govuk_frontend_toolkit (0.32.2)
+    govuk_frontend_toolkit (1.3.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     hike (1.2.3)
@@ -176,7 +175,7 @@ DEPENDENCIES
   airbrake (= 3.1.15)
   capybara (= 2.1.0)
   gds-api-adapters (= 11.1.0)
-  govuk_frontend_toolkit (= 0.32.2)
+  govuk_frontend_toolkit (= 1.3.0)
   logstasher (= 0.4.8)
   nokogiri
   plek (= 1.1.0)


### PR DESCRIPTION
- The old version of the frontend toolkit was the last thing left in
  this Gemfile to be hosted by Gemfury. Increasing this version
  to a much more recent one removes this dependency.

Apologies for the noise yesterday in https://github.com/alphagov/business-support-finder/pull/73 and https://github.com/alphagov/business-support-finder/pull/75. :disappointed:
