### PR TITLE
Send virtual pageview through the GOV.UK Analytics API

### DIFF
--- a/app/assets/javascripts/application/filter-list-items.js
+++ b/app/assets/javascripts/application/filter-list-items.js
@@ -130,7 +130,7 @@
                     + '?' +  filter.$form.serialize();
       
       history.pushState( filter.current_page_state(), null, new_url );
-      window._gaq && _gaq.push(['_trackPageview', new_url]);
+      GOVUK.analytics.trackPageview(new_url);
     },
     track: function(search) {
       var pagePath = window.location.pathname.split('/').pop();


### PR DESCRIPTION
This change wraps the GA event in the newly introduced
analytics API. This will aid in the migration from GA Classic to
Universal Analytics, while remaining functionally equivalent
during the migration.

https://www.pivotaltracker.com/story/show/87738926
