### PR TITLE
Add Universal Analytics tracking for beta service

### DIFF
--- a/app/views/business_support/start.html.erb
+++ b/app/views/business_support/start.html.erb
@@ -29,6 +29,23 @@
   <%= render partial: 'govuk_component/beta_label', locals: { message: "You can also use the <a href='https://www.find-business-support.service.gov.uk/bdt/diagnosticForm'>beta service to find funding and help</a>."} %>
 </div>
 
+<script id="bfsf_cross_domain_analytics">
+  if (typeof window.ga === "function") {
+    ga('create', 'UA-53250464-6', 'auto', {'name': 'transactionTracker'});
+
+    // Load the plugin.
+    ga('require', 'linker');
+    ga('transactionTracker.require', 'linker');
+
+    // Define which domains to autoLink.
+    ga('linker:autoLink', ['service.gov.uk']);
+    ga('transactionTracker.linker:autoLink', ['service.gov.uk']);
+
+    ga('transactionTracker.set', 'anonymizeIp', true);
+    ga('transactionTracker.send', 'pageview');
+  }
+</script>
+
 <% content_for :after_content do %>
   <div id="related-items"></div>
 <% end %>


### PR DESCRIPTION
So that user journeys can be tracked from GOV.UK to the new beta service, we want to enable UA linking across the domains.

This has been mostly copied from the UA service tracking code in frontend.

Finishes off https://www.pivotaltracker.com/n/projects/1261204/stories/89799300.

@edds or others: should this maybe become a component so the code can be shared between [frontend](https://github.com/alphagov/frontend/blob/21251e38d09cd7a131fda438ac6a5a1e5a8a1fe8/app/views/root/_transaction_cross_domain_analytics.html.erb) and here?
