### PR TITLE
Update My Business Support Beta URL

### DIFF
--- a/app/views/business_support/start.html.erb
+++ b/app/views/business_support/start.html.erb
@@ -26,7 +26,7 @@
       </section>
     </div>
   </article>
-  <%= render partial: 'govuk_component/beta_label', locals: { message: "You can also use the <a href='https://www.find-business-support.service.gov.uk/bdt/diagnosticForm'>beta service to find funding and help</a>."} %>
+  <%= render partial: 'govuk_component/beta_label', locals: { message: "You can also use the <a href='https://www.find-business-support.service.gov.uk'>beta service to find funding and help</a>."} %>
 </div>
 
 <% content_for :after_content do %>


### PR DESCRIPTION
Update the My Business Support Beta URL, and remove the /bdt/diagnosticForm path, so that it just points to the domain.
