### PR TITLE
Track beta domain links

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'rails', '3.2.17'
 
 gem 'slimmer', '8.1.0'
-gem 'plek', '1.1.0'
+gem 'plek', '1.10.0'
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,8 +75,7 @@ GEM
     multi_json (1.11.0)
     nokogiri (1.5.11)
     null_logger (0.0.1)
-    plek (1.1.0)
-      builder
+    plek (1.10.0)
     poltergeist (1.4.1)
       capybara (~> 2.1.0)
       cliver (~> 0.2.1)
@@ -178,7 +177,7 @@ DEPENDENCIES
   govuk_frontend_toolkit (= 1.3.0)
   logstasher (= 0.4.8)
   nokogiri
-  plek (= 1.1.0)
+  plek (= 1.10.0)
   poltergeist (= 1.4.1)
   rails (= 3.2.17)
   rspec-rails (= 2.14.0)

--- a/app/assets/javascripts/application/on_ready.js
+++ b/app/assets/javascripts/application/on_ready.js
@@ -1,3 +1,7 @@
 jQuery(function($) {
   GOVUK.filterListItems.init();
+
+  if ($('#beta-business-support-link').length > 0) {
+    GOVUK.analytics.addLinkedTrackerDomain('UA-53250464-6', 'beta_bsf', 'service.gov.uk');
+  }
 });

--- a/app/views/business_support/start.html.erb
+++ b/app/views/business_support/start.html.erb
@@ -26,7 +26,7 @@
       </section>
     </div>
   </article>
-  <%= render partial: 'govuk_component/beta_label', locals: { message: "You can also use the <a href='https://www.find-business-support.service.gov.uk'>beta service to find funding and help</a>."} %>
+  <%= render partial: 'govuk_component/beta_label', locals: { message: "You can also use the <a href='https://www.find-business-support.service.gov.uk' id='beta-business-support-link'>beta service to find funding and help</a>."} %>
 </div>
 
 <% content_for :after_content do %>


### PR DESCRIPTION
This uses the cross domain tracking functionality to track clicks through to the new beta service.

Requires https://github.com/alphagov/static/pull/588 to be merged first.
