### PR TITLE
Bump slimmer for rendering app meta tag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'rails', '3.2.17'
 
-gem 'slimmer', '8.1.0'
+gem 'slimmer', '8.2.1'
 gem 'plek', '1.10.0'
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,7 +134,7 @@ GEM
     simplecov-html (0.8.0)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (8.1.0)
+    slimmer (8.2.1)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -184,7 +184,7 @@ DEPENDENCIES
   sass-rails (= 3.2.6)
   simplecov
   simplecov-rcov
-  slimmer (= 8.1.0)
+  slimmer (= 8.2.1)
   uglifier (>= 1.0.3)
   unicorn
   webmock


### PR DESCRIPTION
So we can track which application renders which page in analytics update
slimmer for a new version which outputs the rendering application.

This contains both https://github.com/alphagov/slimmer/pull/126 and https://github.com/alphagov/slimmer/pull/128
