### PR TITLE
Bump GDS API adapters to 20.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,12 @@ source 'https://rubygems.org'
 
 gem 'rails', '3.2.22'
 
-gem 'slimmer', '8.2.1'
+gem 'slimmer', '8.3.0'
 gem 'plek', '1.10.0'
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '11.1.0'
+  gem 'gds-api-adapters', '20.1.1'
 end
 
 gem 'logstasher', '0.4.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,18 +46,23 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     docile (1.1.3)
+    domain_name (0.5.24)
+      unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.0.2)
-    gds-api-adapters (11.1.0)
+    gds-api-adapters (20.1.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
       plek
-      rest-client (~> 1.6.3)
+      rack-cache
+      rest-client (~> 1.8.0)
     govuk_frontend_toolkit (1.3.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     hike (1.2.3)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     i18n (0.7.0)
     journey (1.0.4)
     json (1.8.3)
@@ -73,6 +78,7 @@ GEM
       treetop (~> 1.4.8)
     mime-types (1.25.1)
     multi_json (1.11.1)
+    netrc (0.10.3)
     nokogiri (1.5.11)
     null_logger (0.0.1)
     plek (1.10.0)
@@ -108,8 +114,10 @@ GEM
     rake (10.4.2)
     rdoc (3.12.2)
       json (~> 1.4)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     rspec-core (2.14.7)
     rspec-expectations (2.14.5)
       diff-lcs (>= 1.1.3, < 2.0)
@@ -134,7 +142,7 @@ GEM
     simplecov-html (0.8.0)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (8.2.1)
+    slimmer (8.3.0)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -156,6 +164,9 @@ GEM
     uglifier (2.4.0)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
     unicorn (4.8.2)
       kgio (~> 2.6)
       rack
@@ -173,7 +184,7 @@ PLATFORMS
 DEPENDENCIES
   airbrake (= 3.1.15)
   capybara (= 2.1.0)
-  gds-api-adapters (= 11.1.0)
+  gds-api-adapters (= 20.1.1)
   govuk_frontend_toolkit (= 1.3.0)
   logstasher (= 0.4.8)
   nokogiri
@@ -184,7 +195,7 @@ DEPENDENCIES
   sass-rails (= 3.2.6)
   simplecov
   simplecov-rcov
-  slimmer (= 8.2.1)
+  slimmer (= 8.3.0)
   uglifier (>= 1.0.3)
   unicorn
   webmock


### PR DESCRIPTION
This changes the user agent to include the app
name in API requests.

Includes a slimmer bump for dependency resolution
reasons.

https://trello.com/c/qkHdtob4/247-bump-gds-api-adapters-everywhere-it-s-used-to-include-user-agent-information
