### PR TITLE
Strip most non-alphanumeric characters from the entered postcode

### DIFF
--- a/app/controllers/business_support_controller.rb
+++ b/app/controllers/business_support_controller.rb
@@ -38,7 +38,9 @@ class BusinessSupportController < ApplicationController
 
   def prepare_facets
     @facets = {}
-    @facets[:postcode] = params[:postcode] if params[:postcode].present?
+    if params[:postcode].present?
+      @facets[:postcode] = params[:postcode].gsub(/[^\w\s]/i, '').strip
+    end
     @facets[:support_types] = params[:support_types].join(',') if params[:support_types]
     @facets[:business_sizes] = params[:business_sizes] if params[:business_sizes].present?
     @facets[:sectors] = params[:sectors] if params[:sectors].present?

--- a/spec/features/finding_support_options_spec.rb
+++ b/spec/features/finding_support_options_spec.rb
@@ -102,6 +102,13 @@ describe "Finding support options" do
         click_on "Refresh results"
         page.assert_selector('li.scheme', count: 1)
       end
+
+      it "should strip postcodes of non-alphanumerics (except non-trailing spaces and underscores) before searching" do
+        # Not stripping underscores is a feature of the regex `\w`.
+        fill_in "Business postcode", :with => "WC2B 6SE] "
+        click_on "Refresh results"
+        page.assert_selector('li.scheme', count: 1)
+      end
     end
   end
 


### PR DESCRIPTION
- We were seeing a lot of Errbit errors on the Business Support API
  because people would typo their postcode in the textbox, for example
  by adding `[` to its beginning or end. See
  https://errbit.production.alphagov.co.uk/apps/536112b50da115127100104b/problems/559a6cb06578630438683e00
  for an example. Deal with this by stripping out all non-alphanumeric
  characters except spaces, but for good measure strip trailing spaces
  at the end of the postcode.
