### PR TITLE
Add meta description tag to start page

### DIFF
--- a/app/views/business_support/start.html.erb
+++ b/app/views/business_support/start.html.erb
@@ -1,4 +1,7 @@
 <% content_for :page_class do %>start-page<% end %>
+<% content_for :head do %>
+  <meta name="description" content="<%= @artefact['details']['description'] %>" />
+<% end %>
 
 <div class="article-container group">
   <article role="article" class="group">

--- a/spec/features/start_page_spec.rb
+++ b/spec/features/start_page_spec.rb
@@ -6,6 +6,10 @@ describe "Start page" do
 
     visit "/#{APP_SLUG}"
 
+    within 'head', visible: :all do
+      page.should have_selector("meta[@name='description']", visible: false)
+    end
+
     within '#content' do
       within 'header' do
         page.should have_content("Finance and support for your business")


### PR DESCRIPTION
Most mainstream formats don't have a meta description tag in the HTML,
for use by external search engines, social media etc.

The lack of a meta-description tag makes some search result snippets
unhelpful, confusing or misleading. Yet the content does have
handwritten descriptions, which we display in site search, so we should
also make them available externally.

https://trello.com/c/gYpErB1T/241-add-meta-description-tag-to-mainstream-content-pages

Also see: https://github.com/alphagov/frontend/pull/842
