### PR TITLE
Bump gds-api-adapters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'plek', '1.10.0'
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '20.1.1'
+  gem 'gds-api-adapters', '~> 24.4.0'
 end
 
 gem 'logstasher', '0.6.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.0.2)
-    gds-api-adapters (20.1.1)
+    gds-api-adapters (24.4.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -90,7 +90,7 @@ GEM
       PriorityQueue (~> 0.1.2)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mime-types (2.6.1)
+    mime-types (2.6.2)
     mini_portile (0.6.2)
     minitest (5.8.0)
     multi_json (1.11.2)
@@ -216,7 +216,7 @@ PLATFORMS
 DEPENDENCIES
   airbrake (~> 4.3.0)
   capybara (~> 2.4.4)
-  gds-api-adapters (= 20.1.1)
+  gds-api-adapters (~> 24.4.0)
   govuk-content-schema-test-helpers
   govuk_frontend_toolkit (= 1.3.0)
   logstasher (= 0.6.2)


### PR DESCRIPTION
This will make `gds-api-adapters` send the content_id to panopticon.

Trello: https://trello.com/c/ZqWkgsej
