### PR TITLE
Update slimmer version and use explicit layout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'rails', '4.2.4'
 gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'
 
-gem 'slimmer', '8.3.0'
+gem 'slimmer', '9.0.0'
 gem 'plek', '1.10.0'
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,7 +172,7 @@ GEM
     simplecov-html (0.8.0)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (8.3.0)
+    slimmer (9.0.0)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -228,7 +228,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   simplecov
   simplecov-rcov
-  slimmer (= 8.3.0)
+  slimmer (= 9.0.0)
   uglifier (>= 1.3.0)
   unicorn
   webmock

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,9 @@
 require 'gds_api/exceptions'
 
 class ApplicationController < ActionController::Base
+  include Slimmer::Template
+  slimmer_template 'wrapper'
+
   protect_from_forgery with: :null_session
 
   rescue_from GdsApi::TimedOutException, :with => :error_503


### PR DESCRIPTION
In Slimmer 9.0.0 the default layout changed from `wrapper` to
`core_layout`, which uses a modern grid and components. We're trying
to move away from `wrapper`, as it contains a lot of very broad styling
and selectors, making it difficult to update without breaking other
apps.

This app can't be moved to `core_layout` yet as it relies on features
that aren't available there yet;
- related sidebar
- breadcrumbs
- Some copy formatting

Once those are available, most likely as components, this app can be
moved away from `wrapper`. In the mean time this gives us an up to
date version of slimmer, and is explicit about using an older layout.
