### PR TITLE
Use publishing-api V2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'plek', '1.10.0'
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '~> 24.4.0'
+  gem 'gds-api-adapters', '~> 25.1'
 end
 
 gem 'logstasher', '0.6.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.0.2)
-    gds-api-adapters (24.4.0)
+    gds-api-adapters (25.1.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -105,7 +105,7 @@ GEM
       multi_json (~> 1.0)
       websocket-driver (>= 0.2.0)
     rack (1.6.4)
-    rack-cache (1.2)
+    rack-cache (1.5.1)
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -216,7 +216,7 @@ PLATFORMS
 DEPENDENCIES
   airbrake (~> 4.3.0)
   capybara (~> 2.4.4)
-  gds-api-adapters (~> 24.4.0)
+  gds-api-adapters (~> 25.1)
   govuk-content-schema-test-helpers
   govuk_frontend_toolkit (= 1.3.0)
   logstasher (= 0.6.2)

--- a/app/notifiers/publishing_api_notifier.rb
+++ b/app/notifiers/publishing_api_notifier.rb
@@ -1,6 +1,7 @@
 class PublishingApiNotifier
   def publish
-    Services.publishing_api.put_content_item(rendered.base_path, rendered.payload)
+    Services.publishing_api.put_content(rendered.content_id, rendered.payload)
+    Services.publishing_api.publish(rendered.content_id, 'minor')
   end
 
 private

--- a/app/presenters/page_content_item.rb
+++ b/app/presenters/page_content_item.rb
@@ -6,9 +6,10 @@ class PageContentItem
 
   def payload
     {
+      base_path: base_path,
       title: data[:title],
       description: data[:description],
-      content_id: data[:content_id],
+      content_id: content_id,
       format: 'placeholder_business_support_finder',
       publishing_app: 'businesssupportfinder',
       rendering_app: 'businesssupportfinder',
@@ -19,6 +20,10 @@ class PageContentItem
         { type: 'exact', path: base_path }
       ]
     }
+  end
+
+  def content_id
+    data[:content_id]
   end
 
 private

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,7 +1,7 @@
-require 'gds_api/publishing_api'
+require 'gds_api/publishing_api_v2'
 
 module Services
   def self.publishing_api
-    @publishing_api ||= GdsApi::PublishingApi.new(Plek.new.find('publishing-api'))
+    @publishing_api ||= GdsApi::PublishingApiV2.new(Plek.new.find('publishing-api'))
   end
 end

--- a/spec/notifiers/publishing_api_notifier_spec.rb
+++ b/spec/notifiers/publishing_api_notifier_spec.rb
@@ -3,14 +3,17 @@ require 'rails_helper'
 RSpec.describe PublishingApiNotifier do
   describe '#publish' do
     it 'publishes the content item' do
-      allow(Services.publishing_api).to receive(:put_content_item)
+      allow(Services.publishing_api).to receive(:put_content)
+      allow(Services.publishing_api).to receive(:publish)
 
       PublishingApiNotifier.new.publish
 
-      expect(Services.publishing_api).to have_received(:put_content_item) do |path, payload|
-        expect(path).to eql("/business-finance-support-finder")
+      expect(Services.publishing_api).to have_received(:put_content) do |content_id, payload|
+        expect(content_id).to eql("6f34c053-2f99-48a3-81e3-955fae00df69")
         expect(payload).to be_valid_against_schema('placeholder')
       end
+
+      expect(Services.publishing_api).to have_received(:publish)
     end
   end
 end


### PR DESCRIPTION
The V2 endpoints work by content_id, which means we can more easily change slugs in the future.

It also allows us to only send the content of the item, not the links. The links will contain the taggings for this content item, and tagging them separately will enable us to tag from more than one tool. Without this "content-only", this app would overwrite taggings done by other apps.

Trello: https://trello.com/c/4doiGxWW
