### PR TITLE
Remove link to beta service

### DIFF
--- a/app/views/business_support/start.html.erb
+++ b/app/views/business_support/start.html.erb
@@ -29,7 +29,6 @@
       </section>
     </div>
   </article>
-  <%= render partial: 'govuk_component/beta_label', locals: { message: "You can also use the <a href='https://www.find-business-support.service.gov.uk' id='beta-business-support-link'>beta service to find funding and help</a>."} %>
 </div>
 
 <% content_for :after_content do %>


### PR DESCRIPTION
Remove link to beta service as it is being discontinued. See Zendesk ticket ref #1391138
