### PR TITLE
Fix schema testing

### DIFF
--- a/app/presenters/page_content_item.rb
+++ b/app/presenters/page_content_item.rb
@@ -9,11 +9,13 @@ class PageContentItem
       base_path: base_path,
       title: data[:title],
       description: data[:description],
-      format: 'placeholder_business_support_finder',
+      document_type: 'placeholder_business_support_finder',
+      schema_name: 'placeholder_business_support_finder',
       publishing_app: 'businesssupportfinder',
       rendering_app: 'businesssupportfinder',
       locale: 'en',
       public_updated_at: Time.now.iso8601,
+      details: {},
       routes: [
         { type: 'exact', path: base_path }
       ]

--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+export REPO_NAME="alphagov/govuk-content-schemas"
+export CONTEXT_MESSAGE="Verify business-support-finder against content schemas"
+
+exec ./jenkins.sh


### PR DESCRIPTION
This fixes the payload sent to the publishing-api and adds a script that will be used to test this application from PRs against https://github.com/alphagov/govuk-content-schemas.

Basically the same as https://github.com/alphagov/calendars/pull/115
