### PR TITLE
Rake task to add support business pages to the search index

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ The schemes themselves (eg [gov.uk/bridge-to-employment-northern-ireland](https:
 - [govuk_content_api](https://github.com/alphagov/govuk_content_api): Provides artefact content and metadata
 - [publishing-api](https://github.com/alphagov/publishing-api): Sends `content_id` to `content-store`
 - [static](https://github.com/alphagov/static): Provides shared GOV.UK assets and templates.
+- [panopticon](https://github.com/alphagov/panopticon): this app sends data to panopticon to register URLs.
+- [rummager](https://github.com/alphagov/rummager): this app indexes its pages for search via Rummager.
 
 ### Running the application
 
@@ -55,6 +57,14 @@ The app will run at [localhost:3024](http://localhost:3024) - or [businesssuppor
 ```
 $ bundle exec rake
 ```
+
+### Publishing to GOV.UK
+
+- `bundle exec rake panopticon:register` will send the business support finder pages to panopticon. Panopticon will register the URL.
+
+### Search indexing
+
+- `bundle exec rake rummager:index_all` will send the data to Rummager for indexing in search.
 
 ## Licence
 

--- a/app/presenters/search_payload_presenter.rb
+++ b/app/presenters/search_payload_presenter.rb
@@ -1,0 +1,30 @@
+class SearchPayloadPresenter
+  attr_reader :business_support_page
+  delegate :slug,
+           :title,
+           :description,
+           :indexable_content,
+           :content_id,
+           to: :business_support_page
+
+  def initialize(business_support_page)
+    @business_support_page = business_support_page
+  end
+
+  def self.call(business_support_page)
+    new(business_support_page).call
+  end
+
+  def call
+    {
+      content_id: content_id,
+      rendering_app: 'businesssupportfinder',
+      publishing_app: 'businesssupportfinder',
+      format: 'custom-application',
+      title: title,
+      description: description,
+      indexable_content: indexable_content,
+      link: "/#{slug}"
+    }
+  end
+end

--- a/app/services/search_indexer.rb
+++ b/app/services/search_indexer.rb
@@ -1,0 +1,30 @@
+class SearchIndexer
+  attr_reader :business_support_page
+  delegate :slug, to: :business_support_page
+
+  def initialize(business_support_page)
+    @business_support_page = business_support_page
+  end
+
+  def self.call(business_support_page)
+    new(business_support_page).call
+  end
+
+  def call
+    Services.rummager.add_document(document_type, document_id, payload)
+  end
+
+private
+
+  def document_type
+    'edition'
+  end
+
+  def document_id
+    "/#{slug}"
+  end
+
+  def payload
+    SearchPayloadPresenter.call(business_support_page)
+  end
+end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,4 +1,5 @@
 require 'gds_api/publishing_api_v2'
+require 'gds_api/rummager'
 
 module Services
   def self.publishing_api
@@ -6,5 +7,9 @@ module Services
       Plek.new.find('publishing-api'),
       bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'
     )
+  end
+
+  def self.rummager
+    @rummager ||= GdsApi::Rummager.new(Plek.find("search"))
   end
 end

--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -1,0 +1,13 @@
+namespace :rummager do
+  desc "Indexes the business support page in Rummager"
+  task index_all: :environment do
+    require 'gds_api/rummager'
+
+    logger = GdsApi::Base.logger = Logger.new(STDERR).tap { |l| l.level = Logger::INFO }
+
+    business_support_page = OpenStruct.new(BusinessSupportPage::DATA)
+    logger.info "Indexing '#{business_support_page.title}' in rummager..."
+
+    SearchIndexer.call(business_support_page)
+  end
+end

--- a/spec/services/search_indexer_spec.rb
+++ b/spec/services/search_indexer_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+require 'gds_api/test_helpers/rummager'
+
+RSpec.describe SearchIndexer do
+  include GdsApi::TestHelpers::Rummager
+
+  before do
+    stub_any_rummager_post_with_queueing_enabled
+  end
+
+  it 'indexes the business support page in rummager' do
+    business_support_page = OpenStruct.new(BusinessSupportPage::DATA)
+    described_class.call(business_support_page)
+
+    assert_rummager_posted_item(
+      _type: 'edition',
+      _id: "/#{business_support_page.slug}",
+      rendering_app: "businesssupportfinder",
+      publishing_app: "businesssupportfinder",
+      format: "custom-application",
+      title: business_support_page.title,
+      description: business_support_page.description,
+      indexable_content: business_support_page.indexable_content,
+      link: "/#{business_support_page.slug}"
+    )
+  end
+end


### PR DESCRIPTION
Previously, panopticon would send artifacts to Rummager. That flow is now being
deprecated in favour of a simpler approach which is to send documents directly
to rummager.

This commit adds a class that allows us to add support business pages to the
search index directly. It also adds a rake task `rummager:index_all` whose job
is to index support business pages in Rummager.

The payload now includes the following extra attributes:
- publishing_app
- rendering_app
- content_id

Before, the search results looked like this:

<img width="1168" alt="business-support-page-old" src="https://cloud.githubusercontent.com/assets/416701/18633372/f6c0a24e-7e73-11e6-97d5-1814cf87f621.png">

It now looks like this:

<img width="1170" alt="business-support-page-new" src="https://cloud.githubusercontent.com/assets/416701/18633378/fd9003b2-7e73-11e6-9a92-1becff367969.png">

Trello ticket: https://trello.com/c/gsHnT5WF/161-epic-send-things-to-rummager-directly-instead-of-via-panopticon
