### PR TITLE
Update gds-api-adapters to 36.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'plek', '1.10.0'
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '~> 25.1'
+  gem 'gds-api-adapters', '~> 36.4.0'
 end
 
 gem 'logstasher', '0.6.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,17 +55,17 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     docile (1.1.3)
-    domain_name (0.5.25)
+    domain_name (0.5.20160826)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.6.0)
-    gds-api-adapters (25.1.0)
+    gds-api-adapters (36.4.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
-      plek
+      plek (>= 1.9.0)
       rack-cache
-      rest-client (~> 1.8.0)
+      rest-client (~> 2.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     govuk-content-schema-test-helpers (1.3.0)
@@ -91,7 +91,9 @@ GEM
       PriorityQueue (~> 0.1.2)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
-    mime-types (2.99.2)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.9.0)
     multi_json (1.11.2)
@@ -108,7 +110,7 @@ GEM
       multi_json (~> 1.0)
       websocket-driver (>= 0.2.0)
     rack (1.6.4)
-    rack-cache (1.5.1)
+    rack-cache (1.6.1)
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -139,10 +141,10 @@ GEM
     raindrops (0.13.0)
     rake (11.2.2)
     request_store (1.2.0)
-    rest-client (1.8.0)
+    rest-client (2.0.0)
       http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rspec-core (3.5.3)
       rspec-support (~> 3.5.0)
     rspec-expectations (3.5.0)
@@ -200,7 +202,7 @@ GEM
       json (>= 1.8.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.1)
+    unf_ext (0.0.7.2)
     unicorn (4.8.2)
       kgio (~> 2.6)
       rack
@@ -220,7 +222,7 @@ PLATFORMS
 DEPENDENCIES
   airbrake (~> 4.3.0)
   capybara (~> 2.4.4)
-  gds-api-adapters (~> 25.1)
+  gds-api-adapters (~> 36.4.0)
   govuk-content-schema-test-helpers
   govuk_frontend_toolkit (= 1.3.0)
   logstasher (= 0.6.2)
@@ -238,4 +240,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.11.2
+   1.13.1

--- a/config/initializers/gds_api_adapters.rb
+++ b/config/initializers/gds_api_adapters.rb
@@ -1,0 +1,1 @@
+GdsApi.config.always_raise_for_not_found = true

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -10,6 +10,6 @@ module Services
   end
 
   def self.rummager
-    @rummager ||= GdsApi::Rummager.new(Plek.find("search"))
+    @rummager ||= GdsApi::Rummager.new(Plek.find("rummager"))
   end
 end

--- a/spec/services/search_indexer_spec.rb
+++ b/spec/services/search_indexer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SearchIndexer do
   include GdsApi::TestHelpers::Rummager
 
   before do
-    stub_any_rummager_post_with_queueing_enabled
+    stub_any_rummager_post
   end
 
   it 'indexes the business support page in rummager' do


### PR DESCRIPTION
Update to the latest version, particularly as we've updated the
Panopticon adapter to stop handling search-related attributes (see
alphagov/gds-api-adapters#592).

Includes a test helper update to remove deprecation warnings.
