### PR TITLE
Replace Content API with Content Store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,17 +5,19 @@ gem 'rails', '~> 4.2', '>= 4.2.7.1'
 gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 2.7.2'
 
-gem 'slimmer', '9.0.1'
+gem 'slimmer', '9.6.0'
 gem 'plek', '1.10.0'
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '~> 36.4.0'
+  gem 'gds-api-adapters', '~> 37.2.0'
 end
 
 gem 'logstasher', '0.6.2'
 gem 'airbrake', '~> 4.3.0'
 gem 'unicorn'
+
+gem 'govuk_navigation_helpers', '~> 2.0.0'
 
 group :development, :test do
   gem 'rspec-rails', '~> 3.3'
@@ -24,6 +26,7 @@ group :development, :test do
   gem 'simplecov-rcov'
   gem 'webmock', :require => false
   gem 'nokogiri'
+  gem 'pry-byebug'
   gem 'poltergeist', '~> 1.6.0'
   gem 'govuk-content-schema-test-helpers'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,7 @@ GEM
       multi_json
     arel (6.0.3)
     builder (3.2.2)
+    byebug (9.0.6)
     capybara (2.4.4)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -50,6 +51,7 @@ GEM
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
     cliver (0.3.2)
+    coderay (1.1.1)
     concurrent-ruby (1.0.2)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
@@ -59,7 +61,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.6.0)
-    gds-api-adapters (36.4.0)
+    gds-api-adapters (37.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -73,7 +75,8 @@ GEM
     govuk_frontend_toolkit (1.3.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    http-cookie (1.0.2)
+    govuk_navigation_helpers (2.0.0)
+    http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.7.0)
     json (1.8.3)
@@ -91,6 +94,7 @@ GEM
       PriorityQueue (~> 0.1.2)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
+    method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
@@ -109,6 +113,13 @@ GEM
       cliver (~> 0.3.1)
       multi_json (~> 1.0)
       websocket-driver (>= 0.2.0)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-byebug (3.4.0)
+      byebug (~> 9.0)
+      pry (~> 0.10)
     rack (1.6.4)
     rack-cache (1.6.1)
       rack (>= 0.4)
@@ -177,14 +188,15 @@ GEM
     simplecov-html (0.8.0)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (9.0.1)
+    slimmer (9.6.0)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
       null_logger
       plek (>= 1.1.0)
-      rack (>= 1.3.5)
+      rack
       rest-client
+    slop (3.6.0)
     sprockets (3.7.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -222,19 +234,21 @@ PLATFORMS
 DEPENDENCIES
   airbrake (~> 4.3.0)
   capybara (~> 2.4.4)
-  gds-api-adapters (~> 36.4.0)
+  gds-api-adapters (~> 37.2.0)
   govuk-content-schema-test-helpers
   govuk_frontend_toolkit (= 1.3.0)
+  govuk_navigation_helpers (~> 2.0.0)
   logstasher (= 0.6.2)
   nokogiri
   plek (= 1.10.0)
   poltergeist (~> 1.6.0)
+  pry-byebug
   rails (~> 4.2, >= 4.2.7.1)
   rspec-rails (~> 3.3)
   sass-rails (~> 5.0)
   simplecov
   simplecov-rcov
-  slimmer (= 9.0.1)
+  slimmer (= 9.6.0)
   uglifier (>= 2.7.2)
   unicorn
   webmock

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The schemes themselves (eg [gov.uk/bridge-to-employment-northern-ireland](https:
 ### Dependencies
 
 - [business-support-api](https://github.com/alphagov/business-support-api): Provides scheme filtering/results
-- [govuk_content_api](https://github.com/alphagov/govuk_content_api): Provides artefact content and metadata
+- [content-store](https://github.com/alphagov/content-store): Provides content and metadata
 - [publishing-api](https://github.com/alphagov/publishing-api): Sends `content_id` to `content-store`
 - [static](https://github.com/alphagov/static): Provides shared GOV.UK assets and templates.
 - [panopticon](https://github.com/alphagov/panopticon): this app sends data to panopticon to register URLs.

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,3 +9,6 @@
 
 // View stylesheets
 @import "views/search";
+
+// GOV.UK components stylesheets
+@import "helpers/govuk-component-helpers";

--- a/app/assets/stylesheets/helpers/_govuk-component-helpers.scss
+++ b/app/assets/stylesheets/helpers/_govuk-component-helpers.scss
@@ -1,0 +1,7 @@
+// GOV.UK components expect to live in a world with a global reset. This CSS
+// might be pushed up to static at some point.
+.govuk-breadcrumbs ol,
+.govuk-related-items ul {
+  padding: 0;
+  margin: 0;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ require 'gds_api/exceptions'
 
 class ApplicationController < ActionController::Base
   include Slimmer::Template
+  include Slimmer::SharedTemplates
   slimmer_template 'wrapper'
 
   protect_from_forgery with: :null_session

--- a/app/presenters/page_content_item.rb
+++ b/app/presenters/page_content_item.rb
@@ -9,7 +9,7 @@ class PageContentItem
       base_path: base_path,
       title: data[:title],
       description: data[:description],
-      document_type: 'placeholder_business_support_finder',
+      document_type: 'business_support_finder',
       schema_name: 'placeholder_business_support_finder',
       publishing_app: 'businesssupportfinder',
       rendering_app: 'businesssupportfinder',

--- a/app/views/business_support/search.html.erb
+++ b/app/views/business_support/search.html.erb
@@ -101,9 +101,9 @@
         <!-- Results -->
         <ul class="results-list">
           <% @schemes.each do |scheme| %>
-            <li class="scheme" data-sectors='<%= formatted_facet_values(scheme.sectors) %>' data-business_sizes='<%= formatted_facet_values(scheme.business_sizes) %>' data-types='<%= formatted_facet_values(scheme.support_types) %>' data-stages='<%= formatted_facet_values(scheme.stages) %>'>
-              <h3><a href="<%= scheme.web_url %>"><%= scheme.title %></a></h3>
-              <p><%= scheme.short_description %></p>
+            <li class="scheme" data-sectors='<%= formatted_facet_values(scheme["sectors"]) %>' data-business_sizes='<%= formatted_facet_values(scheme["business_sizes"]) %>' data-types='<%= formatted_facet_values(scheme["support_types"]) %>' data-stages='<%= formatted_facet_values(scheme["stages"]) %>'>
+              <h3><a href="<%= scheme["web_url"] %>"><%= scheme["title"] %></a></h3>
+              <p><%= scheme["short_description"] %></p>
             </li>
           <% end %>
         </ul>

--- a/app/views/business_support/start.html.erb
+++ b/app/views/business_support/start.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_class do %>start-page<% end %>
 <% content_for :head do %>
-  <meta name="description" content="<%= @artefact['details']['description'] %>" />
+  <meta name="description" content="<%= @content_item['description'] %>" />
 <% end %>
 
 <div class="article-container group">
@@ -32,5 +32,7 @@
 </div>
 
 <% content_for :after_content do %>
-  <div id="related-items"></div>
+  <div class="related-container">
+    <%= render partial: 'govuk_component/related_items', locals: @navigation_helpers.related_items %>
+  </div>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,19 +7,25 @@
     <!--[if IE 7]><%= stylesheet_link_tag "application-ie7.css" %><![endif]-->
     <!--[if IE 8]><%= stylesheet_link_tag "application-ie8.css" %><![endif]-->
     <%= yield :head %>
+    <%= render partial: 'govuk_component/analytics_meta_tags', locals: { content_item: @content_item } %>
+    <% if @meta_section %>
+      <meta name="govuk:section" content="<%= @meta_section %>">
+    <% end %>
   </head>
   <body class="mainstream">
+    <div class="header-context"><!-- Deliberately empty. This will prevent Slimmer from adding the artefact-breadcrumb. --></div>
     <div id="wrapper" class="answer business-support-finder <%= yield :page_class %>">
+      <%= render partial: 'govuk_component/breadcrumbs', locals: @navigation_helpers.breadcrumbs %>
       <% if content_for?(:after_content) %><div class="grid-row"><% end %>
-      <main id="content" role="main">
-        <header class="page-header group">
-          <div>
-            <h1>Finance and support for your business</h1>
-          </div>
-        </header>
-        <%= yield %>
-      </main>
-      <%= yield :after_content %>
+        <main id="content" role="main">
+          <header class="page-header group">
+            <div>
+              <h1>Finance and support for your business</h1>
+            </div>
+          </header>
+          <%= yield %>
+        </main>
+        <%= yield :after_content %>
       <% if content_for?(:after_content) %></div><% end %>
     </div>
     <%= javascript_include_tag "application" %>

--- a/config/initializers/gds_api_adapters.rb
+++ b/config/initializers/gds_api_adapters.rb
@@ -1,1 +1,0 @@
-GdsApi.config.always_raise_for_not_found = true

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,7 +1,14 @@
+require 'gds_api/content_store'
 require 'gds_api/publishing_api_v2'
 require 'gds_api/rummager'
 
 module Services
+  def self.content_store
+    @content_store ||= GdsApi::ContentStore.new(
+      Plek.new.find('content-store')
+    )
+  end
+
   def self.publishing_api
     @publishing_api ||= GdsApi::PublishingApiV2.new(
       Plek.new.find('publishing-api'),

--- a/spec/controllers/business_support_controller_spec.rb
+++ b/spec/controllers/business_support_controller_spec.rb
@@ -38,28 +38,6 @@ RSpec.describe BusinessSupportController do
       end
     end
 
-    it "should fetch the artefact and send it to slimmer" do
-      artefact_data = artefact_for_slug(APP_SLUG)
-      content_api_has_an_artefact(APP_SLUG, artefact_data)
-
-      get :index
-
-      expect(response.headers[Slimmer::Headers::ARTEFACT_HEADER]).to eq(artefact_data.to_json)
-    end
-
-    it "should 503 if content_api times out" do
-      WebMock.stub_request(:get, %r{\A#{GdsApi::TestHelpers::ContentApi::CONTENT_API_ENDPOINT}}).to_timeout
-
-      get :index
-      expect(response.status).to eq(503)
-    end
-
-    it "should set the slimmer format header" do
-      get :index
-
-      expect(response.headers["#{Slimmer::Headers::HEADER_PREFIX}-Format"]).to eq("finder")
-    end
-
     it "should return 404 for invalid UTF-8 in params" do
       get :index, "sectors"=>"travel-and-leisure", "stage"=>"pre-start", "size"=>"under-10", "types"=>"acux10764\xC0\xBEz1\xC0\xBCz2a\x90bcxuca10764"
 

--- a/spec/features/start_page_spec.rb
+++ b/spec/features/start_page_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe "Start page" do
+  before do
+    stub_request(:get, %r{#{Plek.new.find("static")}/templates/locales})
+      .to_return(body: {}.to_json)
+  end
 
   specify "Inspecting the start page" do
 
@@ -21,6 +25,7 @@ RSpec.describe "Start page" do
         end
       end
     end
-    expect(page).to have_selector("#test-related")
+    expect(page).to have_css(shared_component_selector('breadcrumbs'))
+    expect(page).to have_css(shared_component_selector('related_items'))
   end
 end

--- a/spec/support/gds_api.rb
+++ b/spec/support/gds_api.rb
@@ -1,20 +1,13 @@
 require 'webmock'
 require 'gds_api/test_helpers/business_support_api'
-require 'gds_api/test_helpers/content_api'
+require 'gds_api/test_helpers/business_support_helper'
+require 'gds_api/test_helpers/content_store'
 
 RSpec.configure do |config|
-  config.include GdsApi::TestHelpers::BusinessSupportApi, :type => :controller
-  config.include GdsApi::TestHelpers::ContentApi, :type => :controller
-  config.before(:each, :type => :controller) do
-    stub_content_api_default_artefact
+  config.include GdsApi::TestHelpers::BusinessSupportApi
+  config.include GdsApi::TestHelpers::ContentStore
+  config.before(:each) do
+    content_store_has_item("/#{APP_SLUG}")
     setup_business_support_api_schemes_stubs
-  end
-
-  config.include GdsApi::TestHelpers::BusinessSupportApi, :type => :feature
-  config.include GdsApi::TestHelpers::ContentApi, :type => :feature
-  config.before(:each, :type => :feature) do
-    stub_content_api_default_artefact
-    setup_business_support_api_schemes_stubs
-    setup_content_api_business_support_schemes_stubs
   end
 end

--- a/spec/support/slimmer.rb
+++ b/spec/support/slimmer.rb
@@ -1,1 +1,1 @@
-require 'slimmer/test'
+require 'slimmer/rspec'


### PR DESCRIPTION
The Content Store will be used to render breadcrumbs, sidebar and meta tags instead of the Content API. This commit replaces all instances of the Content API with the Content Store.

Trello: https://trello.com/c/MmMEBrm7/174-render-breadcrumb-sidebar-meta-tags-from-content-store-in-business-support-finder

Before:

![screen shot 2016-10-27 at 10 45 30](https://cloud.githubusercontent.com/assets/444232/19762620/9974140e-9c32-11e6-9f2b-3398a7662809.png)

After:

![screen shot 2016-10-27 at 10 45 37](https://cloud.githubusercontent.com/assets/444232/19762622/9de64d9a-9c32-11e6-9739-10a1f456aecf.png)
