### PR TITLE
Register routes via publishing-api instead of panopticon

### DIFF
--- a/app/presenters/business_support_page.rb
+++ b/app/presenters/business_support_page.rb
@@ -5,8 +5,12 @@ class BusinessSupportPage
     title: "Finance and support for your business",
     description: "Find business finance, support, grants and loans backed by the government.",
     need_id: "100115",
+
+    # Sending an empty array for `paths` and `prefixes` will make sure we don't
+    # register routes in Panopticon.
     paths: [],
-    prefixes: ["/#{APP_SLUG}"],
+    prefixes: [],
+
     state: "live",
     indexable_content: "Business finance and support finder"
   }

--- a/app/presenters/page_content_item.rb
+++ b/app/presenters/page_content_item.rb
@@ -10,14 +10,14 @@ class PageContentItem
       title: data[:title],
       description: data[:description],
       document_type: 'business_support_finder',
-      schema_name: 'placeholder_business_support_finder',
+      schema_name: 'generic',
       publishing_app: 'businesssupportfinder',
       rendering_app: 'businesssupportfinder',
       locale: 'en',
       public_updated_at: Time.now.iso8601,
       details: {},
       routes: [
-        { type: 'exact', path: base_path }
+        { type: 'prefix', path: base_path }
       ]
     }
   end

--- a/spec/notifiers/publishing_api_notifier_spec.rb
+++ b/spec/notifiers/publishing_api_notifier_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe PublishingApiNotifier do
 
       expect(Services.publishing_api).to have_received(:put_content) do |content_id, payload|
         expect(content_id).to eql("6f34c053-2f99-48a3-81e3-955fae00df69")
-        expect(payload).to be_valid_against_schema('placeholder')
+        expect(payload).to be_valid_against_schema('generic')
       end
 
       expect(Services.publishing_api).to have_received(:publish)

--- a/spec/presenters/page_content_item_spec.rb
+++ b/spec/presenters/page_content_item_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe PageContentItem do
     it 'is valid against the schema' do
       payload = PageContentItem.new.payload
 
-      expect(payload).to be_valid_against_schema('placeholder')
+      expect(payload).to be_valid_against_schema('generic')
     end
 
     it 'has the correct data' do


### PR DESCRIPTION
This PR makes this application register its routes via the publishing-api instead of content-store.

It's part of the mainstream preparatory work to remove routing from panopticon.

https://trello.com/c/6eOYmUnL/1-register-routes-via-the-publishing-api-for-publisher-formats