### PR TITLE
Add build parameters for content schema tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,7 @@
 
 REPOSITORY = 'business-support-finder'
 APPLICATION_NAME = 'businesssupportfinder'
+DEFAULT_SCHEMA_BRANCH = 'deployed-to-production'
 
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
@@ -18,10 +19,30 @@ node {
       maxConcurrentTotal: 0,
       paramsToUseForLimit: 'business-support-finder',
       throttleEnabled: true,
-      throttleOption: 'category']
+      throttleOption: 'category'],
+    [$class: 'ParametersDefinitionProperty',
+      parameterDefinitions: [
+        [$class: 'BooleanParameterDefinition',
+          name: 'IS_SCHEMA_TEST',
+          defaultValue: false,
+          description: 'Identifies whether this build is being triggered to test a change to the content schemas'],
+        [$class: 'StringParameterDefinition',
+          name: 'SCHEMA_BRANCH',
+          defaultValue: DEFAULT_SCHEMA_BRANCH,
+          description: 'The branch of govuk-content-schemas to test against']]
+    ],
   ])
 
   try {
+    govuk.initializeParameters([
+      'IS_SCHEMA_TEST': 'false',
+      'SCHEMA_BRANCH': DEFAULT_SCHEMA_BRANCH,
+    ])
+
+    if (!govuk.isAllowedBranchBuild(env.BRANCH_NAME)) {
+      return
+    }
+
     stage("Configure environment") {
       govuk.setEnvar("RAILS_ENV", "test")
     }


### PR DESCRIPTION
Parameterize build so that branches can be built as usual, but deployed-to-production can be triggered whenever a change is pushed to a govuk-content-schemas branch.

https://trello.com/c/S4DZbsPa/285-jenkins-2-migration