### PR TITLE
Remove redundant tag for removing breadcrumb

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,6 @@
     <% end %>
   </head>
   <body class="mainstream">
-    <div class="header-context"><!-- Deliberately empty. This will prevent Slimmer from adding the artefact-breadcrumb. --></div>
     <div id="wrapper" class="answer business-support-finder <%= yield :page_class %>">
       <%= render partial: 'govuk_component/breadcrumbs', locals: @navigation_helpers.breadcrumbs %>
       <% if content_for?(:after_content) %><div class="grid-row"><% end %>


### PR DESCRIPTION
This app uses the GOV.UK Component to render the breadcrumb. The tag removed in this was previously necessary to instruct Slimmer to hide the old breadcrumb. We no longer need it because the CSS and HTML have been completely removed from static in https://github.com/alphagov/static/pull/879.

https://trello.com/c/7wohUbyo